### PR TITLE
Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Config
+config.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/bash.py
+++ b/bash.py
@@ -11,8 +11,8 @@ with open("config.json", "r") as config:
 
 BASH_PROFILE = json_config['BASH_PROFILE']
 HOME = str(Path.home())
-PATH = HOME + "/" + json_config['BASH_PROFILE']
-BACKUP_PATH = HOME + "/bash-manager/" + json_config['BASH_PROFILE']
+PATH = HOME + "/" + BASH_PROFILE
+BACKUP_PATH = HOME + "/bash-manager/" + BASH_PROFILE
 ACTIVE = BACKUP_PATH + "_active"
 
 # opens bash file in vim or vscode (defaults to vim)

--- a/bash.py
+++ b/bash.py
@@ -1,15 +1,18 @@
 import argparse
+import json
 import os
 import subprocess
 from pathlib import Path
 from shutil import copyfile
 
 # i use zsh, hence the name. you may have another profile name, so change here:
-BASH_PROFILE = ".zsh_aliases"
+with open("config.json", "r") as config:
+    json_config = json.load(config)
 
+BASH_PROFILE = json_config['BASH_PROFILE']
 HOME = str(Path.home())
-PATH = HOME + "/" + BASH_PROFILE
-BACKUP_PATH = HOME + "/bash-manager/" + BASH_PROFILE
+PATH = HOME + "/" + json_config['BASH_PROFILE']
+BACKUP_PATH = HOME + "/bash-manager/" + json_config['BASH_PROFILE']
 ACTIVE = BACKUP_PATH + "_active"
 
 # opens bash file in vim or vscode (defaults to vim)

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,16 @@ def setup():
     settings = {"BASH_PROFILE": b_profile}
     with open("config.json", "w+") as config:
         json.dump(settings, config)
-    shutil.move(os.getcwd(), str(Path.home()))
-    print("\nbash-manager has been moved to ~/bash-manager\n")
-    print("""to enable default behavior, please execute: 
-                $ python3 ~/bash-manager/bash.py --default\n""")
+    
+    HOME = str(Path.home())
+    CUR_DIR = os.getcwd()
+    if CUR_DIR != HOME + '/bash-manager':
+        shutil.move(CUR_DIR, HOME)
+        print("\nbash-manager has been moved to ~/bash-manager\n")
+        print("""to enable default behavior, please execute: 
+                    $ python3 ~/bash-manager/bash.py --default\n""")
+    else:
+        print(f"\nbash profile changed to {b_profile}\n")
+
 if __name__ == "__main__":
     setup()

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,3 @@ def setup():
                 $ python3 ~/bash-manager/bash.py --default\n""")
 if __name__ == "__main__":
     setup()
-    os.chdir(str(Path.home()) + "/bash-manager")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+import os
+import shutil
+
+def setup():
+    b_profile = input("Please enter filename of bash profile: ").strip()
+    settings = {"BASH_PROFILE": b_profile}
+    with open("config.json", "w+") as config:
+        json.dump(settings, config)
+    shutil.move(os.getcwd(), str(Path.home()))
+
+if __name__ == "__main__":
+    setup()

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ def setup():
     with open("config.json", "w+") as config:
         json.dump(settings, config)
     shutil.move(os.getcwd(), str(Path.home()))
-
+    print("\nbash-manager has been moved to ~/bash-manager\n")
+    print("""to enable default behavior, please execute: 
+                $ python3 ~/bash-manager/bash.py --default\n""")
 if __name__ == "__main__":
     setup()
+    os.chdir(str(Path.home()) + "/bash-manager")


### PR DESCRIPTION
This PR would add a ```setup.py``` file to the bash-manager, enabling users to run ```python3 setup.py```, which would then prompt them for the name of their bash config file and create a ```config.json``` file to hold the information. It will also automatically move the directory to the user's home directory. It automates some of the instructions dictated in the README.